### PR TITLE
Use find_package for PortAudio and Vorbisfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(GLEW REQUIRED)
 find_package(GLUT REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(GLFW REQUIRED)
+find_package(PortAudio REQUIRED)
+find_package(Vorbis REQUIRED)
 
 if (NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     # list of files for which we add a copy rule
@@ -43,4 +45,12 @@ set(SOURCE_FILES
 
 add_executable(0x20_Colors ${SOURCE_FILES})
 
-TARGET_LINK_LIBRARIES(0x20_Colors ${OPENGL_LIBRARIES} ${GLEW_LIBRARIES} ${GLUT_LIBRARIES} ${GLFW_LIBRARIES} m ${CMAKE_CURRENT_BINARY_DIR}/${BASS_LIBRARY} vorbisfile portaudio)
+TARGET_LINK_LIBRARIES(0x20_Colors
+  m
+  ${OPENGL_LIBRARIES}
+  ${GLEW_LIBRARIES}
+  ${GLUT_LIBRARIES}
+  ${GLFW_LIBRARIES}
+  ${PORTAUDIO_LIBRARIES}
+  ${VORBIS_LIBRARIES}
+)

--- a/cmake/Modules/FindPortAudio.cmake
+++ b/cmake/Modules/FindPortAudio.cmake
@@ -1,0 +1,38 @@
+# Locate the PortAudio library
+# This module defines the following variables:
+# PORTAUDIO_LIBRARIES, the name of the library;
+# PORTAUDIO_INCLUDE_DIR, where to find glfw include files.
+# PORTAUDIO_FOUND, true if both the PORTAUDIO_LIBRARIES and PORTAUDIO_INCLUDE_DIR have been found.
+#
+# Usage example to compile an "executable" target to the glfw library:
+#
+# FIND_PACKAGE (portaudio REQUIRED)
+# INCLUDE_DIRECTORIES (${PORTAUDIO_INCLUDE_DIR})
+# ADD_EXECUTABLE (executable ${EXECUTABLE_SRCS})
+# TARGET_LINK_LIBRARIES (executable ${PORTAUDIO_LIBRARIES})
+
+# Search for the include file
+find_path(PORTAUDIO_INCLUDE_DIR
+  NAMES
+    portaudio.h
+  PATHS
+    /usr/include
+    /usr/local/include
+)
+
+find_library(PORTAUDIO_LIBRARIES
+  NAMES
+    portaudio
+  PATHS
+    /usr/lib
+    /usr/local/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PortAudio REQUIRED_VARS PORTAUDIO_LIBRARIES PORTAUDIO_INCLUDE_DIR)
+
+set(PORTAUDIO_FOUND 0)
+if(PORTAUDIO_LIBRARIES AND PORTAUDIO_INCLUDE_DIR)
+  set(PORTAUDIO_FOUND 1)
+endif()
+

--- a/cmake/Modules/FindVorbis.cmake
+++ b/cmake/Modules/FindVorbis.cmake
@@ -1,0 +1,40 @@
+# Locate the Vorbis library
+# This module defines the following variables:
+# VORBIS_LIBRARIES, the name of the library;
+# VORBIS_INCLUDE_DIR, where to find glfw include files.
+# VORBIS_FOUND, true if both the VORBIS_LIBRARIES and VORBIS_INCLUDE_DIR have been found.
+#
+# Usage example to compile an "executable" target to the glfw library:
+#
+# FIND_PACKAGE (vorbis REQUIRED)
+# INCLUDE_DIRECTORIES (${VORBIS_INCLUDE_DIR})
+# ADD_EXECUTABLE (executable ${EXECUTABLE_SRCS})
+# TARGET_LINK_LIBRARIES (executable ${VORBIS_LIBRARIES})
+
+# Search for the include file
+find_path(VORBIS_INCLUDE_DIR
+  NAMES
+    vorbisfile.h
+  PATHS
+    /usr/include
+    /usr/local/include
+  PATH_SUFFIXES
+    vorbis
+)
+
+find_library(VORBIS_LIBRARIES
+  NAMES
+    vorbisfile vorbis
+  PATHS
+    /usr/lib
+    /usr/local/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Vorbis REQUIRED_VARS VORBIS_LIBRARIES VORBIS_INCLUDE_DIR)
+
+set(VORBIS_FOUND 0)
+if(VORBIS_LIBRARIES AND VORBIS_INCLUDE_DIR)
+  set(VORBIS_FOUND 1)
+endif()
+

--- a/state.h
+++ b/state.h
@@ -6,7 +6,6 @@
 #define INC_0X20_COLORS_STATE_H
 
 #include <GLFW/glfw3.h>
-#include <malloc.h>
 #include <vector>
 #include <string>
 #include <stdlib.h>


### PR DESCRIPTION
I wrote some CMake modules which should find these libraries.

Also removed the `#include <malloc.h>` again as it's not portable.  Use `stdlib.h` or `cstdlib` instead if you need the `malloc(3)` function.
